### PR TITLE
Fix heap use after free

### DIFF
--- a/source/compiler.c
+++ b/source/compiler.c
@@ -754,7 +754,7 @@ unsigned char* collateCompiler(Compiler* compiler, int* size) {
 	emitByte(&collation, &capacity, &count, OP_EOF); //terminate bytecode
 
 	//finalize
-	SHRINK_ARRAY(unsigned char, collation, capacity, count);
+	collation = SHRINK_ARRAY(unsigned char, collation, capacity, count);
 
 	*size = count;
 


### PR DESCRIPTION
Asan detected a heap-use-after-free in compiler.c as collation was being freed and never reassigned to.
Reassigning collation to the shrunk array fixes this